### PR TITLE
cherish: qcom: Allow a device to manually override which HALs it wants …

### DIFF
--- a/config/BoardConfigQcom.mk
+++ b/config/BoardConfigQcom.mk
@@ -128,6 +128,11 @@ else
     QCOM_HARDWARE_VARIANT := $(TARGET_BOARD_PLATFORM)
 endif
 
+# Allow a device to manually override which HALs it wants to use
+ifneq ($(OVERRIDE_QCOM_HARDWARE_VARIANT),)
+QCOM_HARDWARE_VARIANT := $(OVERRIDE_QCOM_HARDWARE_VARIANT)
+endif
+
 # Allow a device to opt-out hardset of PRODUCT_SOONG_NAMESPACES
 QCOM_SOONG_NAMESPACE ?= hardware/qcom-caf/$(QCOM_HARDWARE_VARIANT)
 PRODUCT_SOONG_NAMESPACES += $(QCOM_SOONG_NAMESPACE)


### PR DESCRIPTION
…to use

Like for an example: although ZUK Z2 is actually msm8996, its community built 4.4 kernel
needs msm8998 HALs for proper functionality (VIDC doesn't work at all with msm8996 media HAL).
This is done by adding the following line in BoardConfig:
OVERRIDE_QCOM_HARDWARE_VARIANT := msm8998

Change-Id: Icf26be96facad5638abd5fb269c41f4e852c16a9
Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>
Signed-off-by: Josh Fox (XlxFoXxlX) <joshfox87@gmail.com>
Signed-off-by: dhimanparas20 <dhimanparas20@gmail.com>