### PR TITLE
Change codename of Redmi 9/Poco M2

### DIFF
--- a/cherish.devices
+++ b/cherish.devices
@@ -37,7 +37,7 @@ beryllium
 lmi
 umi
 venus
-lava
+lancelot
 surya
 vince
 whyred


### PR DESCRIPTION
Device is not unified anymore