### PR TITLE
rro_overlays: bring back NexusLauncherResOverlay, this one still needed for large screen

### DIFF
--- a/rro_overlays/NexusLauncherResOverlay/Android.bp
+++ b/rro_overlays/NexusLauncherResOverlay/Android.bp
@@ -1,0 +1,6 @@
+runtime_resource_overlay {
+    name: "NexusLauncherResOverlay",
+    theme: "NexusLauncherResOverlay",
+    sdk_version: "current",
+    product_specific: true
+}

--- a/rro_overlays/NexusLauncherResOverlay/AndroidManifest.xml
+++ b/rro_overlays/NexusLauncherResOverlay/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2023 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.android.launcher.resources.overlay"
+    android:versionCode="1"
+    android:allowBackup="false"
+    android:versionName="1.0">
+    <application android:hasCode="false" />
+    <overlay
+      android:targetPackage="com.google.android.apps.nexuslauncher"
+      android:targetName="NexusLauncherResOverlay"
+      android:isStatic="true"
+      android:priority="1"/>
+</manifest>

--- a/rro_overlays/NexusLauncherResOverlay/res/values/dimens.xml
+++ b/rro_overlays/NexusLauncherResOverlay/res/values/dimens.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources>
+    <!-- The max scale for the wallpaper when it's zoomed in -->
+    <item type="dimen" format="float" name="config_wallpaperMaxScale">@*android:dimen/config_wallpaperMaxScale</item>
+    <!-- Height of the bottom taskbar not including decorations like rounded corners. -->
+    <dimen name="taskbar_size">@*android:dimen/taskbar_frame_height</dimen>
+</resources>


### PR DESCRIPTION
Picked here: https://github.com/CherishOS/android_vendor_cherish/commit/f925de66c6885ef341cd4e9b6591f9b440a6dd9a
Removed here: https://github.com/CherishOS/android_vendor_cherish/commit/f2cc317fef4d0584a7fce8972e4d5878186f8da4
Build recipe still exist: https://github.com/CherishOS/android_vendor_cherish/blob/5bbc9c68967a96ecbfec8ececc582d5d712353a0/config/common.mk#L321