### PR TITLE
vendor: fix boot animation issue

### DIFF
--- a/config/bootanimation.mk
+++ b/config/bootanimation.mk
@@ -5,6 +5,12 @@ else ifeq ($(TARGET_BOOT_ANIMATION_RES),1440)
      PRODUCT_COPY_FILES += vendor/cherish/bootanimation/bootanimation_1440.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation.zip
 else ifeq ($(TARGET_BOOT_ANIMATION_RES),720)
      PRODUCT_COPY_FILES += vendor/cherish/bootanimation/bootanimation_720.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation.zip
+else ifeq ($(TARGET_PIXEL_BOOT_ANIMATION_RES),1080)
+     PRODUCT_COPY_FILES += vendor/cherish/bootanimation/bootanimation_1080.zip:$(TARGET_COPY_OUT_SYSTEM)/media/bootanimation.zip
+else ifeq ($(TARGET_PIXEL_BOOT_ANIMATION_RES),1440)
+     PRODUCT_COPY_FILES += vendor/cherish/bootanimation/bootanimation_1440.zip:$(TARGET_COPY_OUT_SYSTEM)/media/bootanimation.zip
+else ifeq ($(TARGET_PIXEL_BOOT_ANIMATION_RES),720)
+     PRODUCT_COPY_FILES += vendor/cherish/bootanimation/bootanimation_720.zip:$(TARGET_COPY_OUT_SYSTEM)/media/bootanimation.zip
 else
     ifeq ($(TARGET_BOOT_ANIMATION_RES),)
         $(warning "CherishStyle: TARGET_BOOT_ANIMATION_RES is undefined, assuming 1080p")


### PR DESCRIPTION
Add a flag for pixels since Pixels bootanimation is better supported on system partition. If doing a dirty flash or reboot once after a clean flash and bootanimation is not in system, custom boot animation is no longer shown and defaults to generic android animation.